### PR TITLE
 Check passwordless capacity for date strictly aganst the date command. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # set-system-time
 Signal K Node server plugin to set system time on time data from GPS
+<br>
+
+![UI image](https://i.imgur.com/K0IZQxG.png "UI image")
+<br>
+<br>
+
+# Configuration Interface
+###  Use sudo when setting the time :
+When this option is checked, **set-system-time plugin** will try to use `sudo` to set the date. 
+It's required that sudo have a password-less access to the `date` command.
+
+
+To give `sudo` a no password access only to the `date` command, you can add the following line to your sudoers file : 
+```
+pi ALL=(ALL) NOPASSWD: /bin/date
+```
+ --- *In this example, **pi** is the username that run the signalk server. Yours could be different.*

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function (app) {
           const useSudo = typeof options.sudo === 'undefined' || options.sudo
           const setDate = `date --iso-8601 -u -s "${datetime}"`
           const command = useSudo
-            ? `if sudo -S -p '' echo -n < /dev/null 2> /dev/null ; then sudo ${setDate} ; else exit 3 ; fi`
+            ? `if sudo -n date &> /dev/null ; then sudo ${setDate} ; else exit 3 ; fi`
             : setDate
           child = require('child_process').spawn('sh', ['-c', command])
           child.on('exit', value => {


### PR DESCRIPTION
This fix https://github.com/SignalK/set-system-time/issues/4

Previously,  the ability of using the `date` command without password was checked aganst the `echo` command. 
Witch would fail in restrictive context where only  `sudo date` command is allowed password less and not `sudo echo` 

Sudoers entry for reference : 
```
signalk ALL=(ALL) NOPASSWD: /bin/date
``` 

_Note: The command have been tested the a terminal only._