### PR TITLE
fix: ignore bad timesources. ignore data that is older than our last good value

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,15 +53,8 @@ module.exports = function (app) {
 
   const minimumYear = 2026
 
-  function getDataDir() {
-    if (typeof app.getDataDir === 'function') {
-      return app.getDataDir(plugin.id) || app.getDataDir()
-    }
-    return null
-  }
-
   function getLastGoodTimePath() {
-    const dataDir = getDataDir()
+    const dataDir = typeof app.getDataDirPath === 'function' ? app.getDataDirPath() : null
     if (!dataDir) {
       return null
     }

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ module.exports = function (app) {
   }
 
   const minimumYear = 2026
+  const lastGoodGraceSeconds = 300
 
   function getLastGoodTimePath() {
     const dataDir = typeof app.getDataDirPath === 'function' ? app.getDataDirPath() : null
@@ -183,8 +184,9 @@ module.exports = function (app) {
             }
             if (lastGoodTime) {
               const lastGoodDate = new Date(lastGoodTime)
-              if (!Number.isNaN(lastGoodDate.getTime()) && parsedDate.getTime() < lastGoodDate.getTime()) {
-                lastMessage = `Ignoring GPS time (${datetime}) older than last-good time ${lastGoodTime}`
+              const lastGoodMillis = lastGoodDate.getTime()
+              if (!Number.isNaN(lastGoodMillis) && parsedDate.getTime() + lastGoodGraceSeconds * 1000 < lastGoodMillis) {
+                lastMessage = `Ignoring GPS time (${datetime}) older than last-good time ${lastGoodTime} (grace ${lastGoodGraceSeconds}s)`
                 logError(lastMessage)
                 return
               }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+const fs = require('fs')
+const path = require('path')
+
 module.exports = function (app) {
   const logError =
     app.error ||
@@ -43,20 +46,127 @@ module.exports = function (app) {
 
   let count = 0
   let lastMessage = ''
+  let lastGoodTime = null
   plugin.statusMessage = function () {
     return `${lastMessage} ${count > 0 ? '- system time set ' + count + ' times' : ''}`
   }
 
+  const minimumYear = 2026
+
+  function getDataDir() {
+    if (typeof app.getDataDir === 'function') {
+      return app.getDataDir(plugin.id) || app.getDataDir()
+    }
+    return null
+  }
+
+  function getLastGoodTimePath() {
+    const dataDir = getDataDir()
+    if (!dataDir) {
+      return null
+    }
+    return path.join(dataDir, 'last-good-time.json')
+  }
+
+  function loadLastGoodTime() {
+    const filePath = getLastGoodTimePath()
+    if (!filePath || !fs.existsSync(filePath)) {
+      return null
+    }
+    try {
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+      const datetime = data && data.datetime
+      if (!datetime || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z?$/.test(datetime)) {
+        return null
+      }
+      const parsedDate = new Date(datetime)
+      if (Number.isNaN(parsedDate.getTime())) {
+        return null
+      }
+      return datetime
+    } catch (err) {
+      logError('Failed to read last-good time: ' + err.message)
+      return null
+    }
+  }
+
+  function saveLastGoodTime(datetime) {
+    const filePath = getLastGoodTimePath()
+    if (!filePath) {
+      return
+    }
+    try {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true })
+      fs.writeFileSync(filePath, JSON.stringify({ datetime }), 'utf8')
+    } catch (err) {
+      logError('Failed to write last-good time: ' + err.message)
+    }
+  }
+
+  function setSystemTime(datetime, useSudoFallback, sourceLabel) {
+    const dateStr = datetime.replace('T', ' ').replace(/\.\d+Z?$|Z$/, '')
+    const setDate = `date -u -s "${dateStr}"`
+    const label = sourceLabel ? ` (${sourceLabel})` : ''
+
+    const child = require('child_process').spawn('sh', ['-c', setDate])
+    child.on('exit', value => {
+      if (value === 0) {
+        count++
+        lastGoodTime = datetime
+        saveLastGoodTime(datetime)
+        lastMessage = 'System time set to ' + datetime + label
+        debug(lastMessage)
+      } else if (useSudoFallback) {
+        const sudoCommand = `if sudo -n date &> /dev/null ; then sudo ${setDate} ; else exit 3 ; fi`
+        const sudoChild = require('child_process').spawn('sh', ['-c', sudoCommand])
+        sudoChild.on('exit', sudoValue => {
+          if (sudoValue === 0) {
+            count++
+            lastGoodTime = datetime
+            saveLastGoodTime(datetime)
+            lastMessage = 'System time set to ' + datetime + ' (using sudo)' + label
+            debug(lastMessage)
+          } else if (sudoValue === 3) {
+            lastMessage =
+              'Setting time failed. Passwordless sudo not available. Configure sudoers or use Docker image with setuid bit on /usr/bin/date'
+            logError(lastMessage)
+          }
+        })
+        sudoChild.stderr.on('data', function (data) {
+          lastMessage = data.toString()
+          logError(lastMessage)
+        })
+      } else {
+        lastMessage =
+          'Setting time failed. Enable sudo fallback or use Docker image with setuid bit on /usr/bin/date'
+        logError(lastMessage)
+      }
+    })
+    child.stderr.on('data', function (data) {
+      if (!useSudoFallback) {
+        lastMessage = data.toString()
+        logError(lastMessage)
+      }
+    })
+  }
+
   plugin.start = function (options) {
+    lastGoodTime = loadLastGoodTime()
     let stream = app.streambundle.getSelfStream('navigation.datetime')
     if (options && options.interval > 0) {
       stream = stream.debounceImmediate(options.interval * 1000)
     } else {
       stream = stream.take(1)
     }
+    if (!plugin.useNetworkTime(options) && lastGoodTime) {
+      const lastGoodDate = new Date(lastGoodTime)
+      if (!Number.isNaN(lastGoodDate.getTime()) && Date.now() < lastGoodDate.getTime()) {
+        const useSudoFallback = typeof options.sudo === 'undefined' || options.sudo
+        setSystemTime(lastGoodTime, useSudoFallback, 'from last-good time')
+      }
+    }
     plugin.unsubscribes.push(
       stream.onValue(function (datetime) {
-        var child
         if (process.platform == 'win32') {
           console.error("Set-system-time supports only linux-like os's")
         } else {
@@ -67,51 +177,27 @@ module.exports = function (app) {
               logError(lastMessage)
               return
             }
+            const parsedDate = new Date(datetime)
+            if (Number.isNaN(parsedDate.getTime())) {
+              lastMessage = 'Invalid datetime value received: ' + String(datetime).substring(0, 50)
+              logError(lastMessage)
+              return
+            }
+            if (parsedDate.getUTCFullYear() < minimumYear) {
+              lastMessage = `Ignoring GPS time (${datetime}) older than minimum year ${minimumYear}`
+              logError(lastMessage)
+              return
+            }
+            if (lastGoodTime) {
+              const lastGoodDate = new Date(lastGoodTime)
+              if (!Number.isNaN(lastGoodDate.getTime()) && parsedDate.getTime() < lastGoodDate.getTime()) {
+                lastMessage = `Ignoring GPS time (${datetime}) older than last-good time ${lastGoodTime}`
+                logError(lastMessage)
+                return
+              }
+            }
             const useSudoFallback = typeof options.sudo === 'undefined' || options.sudo
-            // Convert ISO 8601 datetime to format compatible with both GNU date and BusyBox date
-            // e.g., "2024-01-10T17:55:03.000Z" → "2024-01-10 17:55:03"
-            const dateStr = datetime.replace('T', ' ').replace(/\.\d+Z?$|Z$/, '')
-            const setDate = `date -u -s "${dateStr}"`
-
-            // First try without sudo (works in Docker with setuid bit on /usr/bin/date)
-            child = require('child_process').spawn('sh', ['-c', setDate])
-            child.on('exit', value => {
-              if (value === 0) {
-                count++
-                lastMessage = 'System time set to ' + datetime
-                debug(lastMessage)
-              } else if (useSudoFallback) {
-                // Try with sudo as fallback
-                const sudoCommand = `if sudo -n date &> /dev/null ; then sudo ${setDate} ; else exit 3 ; fi`
-                const sudoChild = require('child_process').spawn('sh', ['-c', sudoCommand])
-                sudoChild.on('exit', sudoValue => {
-                  if (sudoValue === 0) {
-                    count++
-                    lastMessage = 'System time set to ' + datetime + ' (using sudo)'
-                    debug(lastMessage)
-                  } else if (sudoValue === 3) {
-                    lastMessage =
-                      'Setting time failed. Passwordless sudo not available. Configure sudoers or use Docker image with setuid bit on /usr/bin/date'
-                    logError(lastMessage)
-                  }
-                })
-                sudoChild.stderr.on('data', function (data) {
-                  lastMessage = data.toString()
-                  logError(lastMessage)
-                })
-              } else {
-                lastMessage =
-                  'Setting time failed. Enable sudo fallback or use Docker image with setuid bit on /usr/bin/date'
-                logError(lastMessage)
-              }
-            })
-            child.stderr.on('data', function (data) {
-              // Suppress stderr from first attempt if sudo fallback is enabled
-              if (!useSudoFallback) {
-                lastMessage = data.toString()
-                logError(lastMessage)
-              }
-            })
+            setSystemTime(datetime, useSudoFallback, '')
           }
         }
       })


### PR DESCRIPTION
This PR adds persistence for the last known good datetime and uses it to guard against bad GPS timestamps.
It also introduces a hard minimum year to prevent obvious time resets.

This "minimum last good time" is stored in the data in the plugin’s data.
This way e.g bad fixes in GPS don't result in bogus data.

should be a fix for https://github.com/SignalK/set-system-time/issues/10
and probably https://github.com/SignalK/set-system-time/issues/14 also?