### PR TITLE
doc: add note about docker privieges

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,32 @@ pi ALL=(ALL) NOPASSWD: /bin/date
  --- *In this example, **pi** is the username that run the signalk server. Yours could be different.*
 
 Sudo is not available in Signal K Server image, but setting time should work without it with the latest Docker image.
+
+# Docker
+The plugin needs enough privileges to run `date -s`. In containers this usually means either:
+- passwordless `sudo` for `date`, or
+- setting the setuid bit on the `date` binary inside the image.
+- adding the `SYS_TIME` capability to the container.
+
+Below is a minimal docker compose snippet using inline Dockerfile to enable setuid for `date`:
+```yaml
+services:
+	signalk:
+		build:
+			context: .
+			dockerfile_inline: |
+				FROM signalk/signalk-server:latest
+				RUN if [ -x /usr/bin/date ]; then chmod u+s /usr/bin/date; fi \
+						&& if [ -x /bin/date ]; then chmod u+s /bin/date; fi
+		ports:
+			- "3000:3000"
+```
+
+Alternative without sudo or setuid (capability-based):
+```yaml
+services:
+	signalk:
+		image: signalk/signalk-server:latest
+		cap_add:
+			- SYS_TIME
+```


### PR DESCRIPTION
should fix this: https://github.com/SignalK/set-system-time/issues/15

I added a note of my own, I think the second approach should be better. But tbh I didn't bother to test it. I can remove it if your prefer.