### PR TITLE
chore: upgrade baconjs devDependency from 1.x to 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "author": "teppo.kurki@iki,fi",
   "license": "Apache-2.0",
   "devDependencies": {
-    "baconjs": "^1.0.1"
+    "baconjs": "^3.0.0"
   }
 }


### PR DESCRIPTION
chore: upgrade baconjs devDependency from 1.x to 3.x


## Summary

Align with signalk-server which uses baconjs ^3.0.0.
Only used in `run.js` test script (`Bus`, `push`, `onValue`) — all compatible with 3.x.