### PR TITLE
Fix recurring [object Object] server-log entry from chrony check

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ module.exports = function (app) {
     if ( typeof options.preferNetworkTime !== 'undefined' && options.preferNetworkTime == true ){
       const chronyCmd = "chronyc sources 2> /dev/null | cut -c2 | grep -ce '-\|*'";
       try {
-        validSources = require('child_process').execSync(chronyCmd,{timeout:500});
+        validSources = require('child_process').execSync(chronyCmd,{timeout:500, stdio: ['ignore', 'pipe', 'ignore']});
       } catch (e) {
         return false
       }


### PR DESCRIPTION
### Problem

On a running server, every time the plugin checks for network time it emits a spurious red log entry that renders as:

> [object Object]

With the default update interval this repeats about once per minute and clutters the server log.

### Root cause

useNetworkTime() runs `execSync(chronyCmd, { timeout: 500 })`. With default stdio, execSync forwards the child processs stderr (an empty Buffer here) to the parent process.stderr. The Signal K server log capture stores that Buffer and the admin UI renders the object as `[object Object]`. It does not appear in journald/stdout because an empty buffer write produces no visible text there.

Confirmed with a stack trace captured at the server log chokepoint: process.stderr.write <- child_process.execSync <- plugin.useNetworkTime (index.js).

### Fix

Pass `stdio: [ignore, pipe, ignore]` to the execSync call so the childs stderr is discarded while stdout (used for the source count) is still captured.

Verified on a live Signal K v2 server: before, one [object Object] entry every ~60s; after, none, across a multi-minute window. chrony detection still works.
